### PR TITLE
Add compilation to the `prepublishOnly` script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "cdk:synth": "yarn compile && cdk synth",
     "cdk:deploy": "yarn compile && cdk deploy",
     "cdk:destroy": "yarn compile && cdk destroy",
-    "cdk:version": "yarn compile && cdk --version"
+    "cdk:version": "yarn compile && cdk --version",
+    "prepublishOnly": "yarn compile"
   },
   "author": "Sean Schofield",
   "license": "MIT",


### PR DESCRIPTION
As per `npm` recommendation here:
https://docs.npmjs.com/misc/scripts#use-cases

It's probably a good idea to add the compilation step to the `prepublishOnly` script to ensure it is run before a publish occurs.  This may help prevent incidents like #8.