### PR TITLE
fix: IAM policy of Lambda and S3 bucket policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ dist
 cdk.out
 
 package
+/.idea/*

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@aws-cdk/aws-cloudformation": "1.55.0",
     "@aws-cdk/aws-lambda": "1.55.0",
     "@aws-cdk/aws-s3": "1.55.0",
+    "@aws-cdk/aws-iam": "1.55.0",
     "@aws-cdk/core": "1.55.0"
   },
   "devDependencies": {

--- a/src/resource/auto-delete-bucket.ts
+++ b/src/resource/auto-delete-bucket.ts
@@ -1,39 +1,52 @@
-import { Code, Runtime, SingletonFunction } from '@aws-cdk/aws-lambda'
-import { Construct, RemovalPolicy, Duration } from '@aws-cdk/core'
+import {Code, Runtime, SingletonFunction} from '@aws-cdk/aws-lambda'
+import {Construct, RemovalPolicy, Duration} from '@aws-cdk/core'
 import {
-  CustomResource,
-  CustomResourceProvider
+    CustomResource,
+    CustomResourceProvider
 } from '@aws-cdk/aws-cloudformation'
-import { Bucket, BucketProps } from '@aws-cdk/aws-s3'
-import path = require('path')
+import {Bucket, BucketProps} from '@aws-cdk/aws-s3'
+import {PolicyStatement, ServicePrincipal} from "@aws-cdk/aws-iam"
+
+const path = require('path')
 
 export class AutoDeleteBucket extends Bucket {
-  constructor(scope: Construct, id: string, props: BucketProps = {}) {
-    super(scope, id, {
-      ...props,
-      removalPolicy: RemovalPolicy.DESTROY
-    })
+    constructor(scope: Construct, id: string, props: BucketProps = {}) {
+        super(scope, id, {
+            ...props,
+            removalPolicy: RemovalPolicy.DESTROY
+        })
 
-    const lambda = new SingletonFunction(this, 'AutoBucketHandler', {
-      uuid: '7677dc81-117d-41c0-b75b-db11cb84bb70',
-      runtime: Runtime.NODEJS_10_X,
-      code: Code.asset(path.join(__dirname, '../lambda')),
-      handler: 'main.handler',
-      lambdaPurpose: 'AutoBucket',
-      timeout: Duration.minutes(15)
-    })
+        const lambda = new SingletonFunction(this, 'AutoBucketHandler', {
+            uuid: '7677dc81-117d-41c0-b75b-db11cb84bb70',
+            runtime: Runtime.NODEJS_10_X,
+            code: Code.fromAsset(path.join(__dirname, '../lambda')),
+            handler: 'main.handler',
+            lambdaPurpose: 'AutoBucket',
+            timeout: Duration.minutes(15)
+        })
 
-    const provider = CustomResourceProvider.lambda(lambda)
+        const provider = CustomResourceProvider.lambda(lambda)
 
-    // allow the bucket contents to be read and deleted by the lambda
-    this.grantReadWrite(lambda)
+        // allow the bucket contents to be read and deleted by the lambda
+        lambda.addToRolePolicy(new PolicyStatement({
+            actions: ["s3:List*", "s3:Delete*"],
+            resources: [
+                "*"
+            ],
+        }))
 
-    new CustomResource(this, 'AutoBucket', {
-      provider,
-      resourceType: 'Custom::AutoDeleteBucket',
-      properties: {
-        bucketName: this.bucketName
-      }
-    })
-  }
+        this.addToResourcePolicy(new PolicyStatement({
+            actions: ["*"],
+            resources: [this.arnForObjects('*')],
+            principals: [new ServicePrincipal('lambda')],
+        }))
+
+        new CustomResource(this, 'AutoBucket', {
+            provider,
+            resourceType: 'Custom::AutoDeleteBucket',
+            properties: {
+                bucketName: this.bucketName
+            }
+        })
+    }
 }


### PR DESCRIPTION
By default, the construct failed to delete the S3 bucket if it had files uploaded by other IAM users within the account OR other IAM users (cross-account S3 uploads).