### PR TITLE
fix unsupported lambda runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mobileposse/auto-delete-bucket",
-  "version": "1.55.0",
+  "version": "1.56.0",
   "description": "CDK Construct for automatically deleting bucket contents which allows the bucket to be deleted when the stack is destroyed.",
   "main": "dist/src/resource/auto-delete-bucket.js",
   "types": "dist/src/resource/auto-delete-bucket.d.ts",

--- a/src/resource/auto-delete-bucket.ts
+++ b/src/resource/auto-delete-bucket.ts
@@ -16,7 +16,7 @@ export class AutoDeleteBucket extends Bucket {
 
     const lambda = new SingletonFunction(this, 'AutoBucketHandler', {
       uuid: '7677dc81-117d-41c0-b75b-db11cb84bb70',
-      runtime: Runtime.NODEJS_10_X,
+      runtime: Runtime.NODEJS_12_X,
       code: Code.asset(path.join(__dirname, '../lambda')),
       handler: 'main.handler',
       lambdaPurpose: 'AutoBucket',


### PR DESCRIPTION
I think AWS dropped support for node 10x lambda runtimes. Bumping the auto delete lambda to a supported version.
<img width="1114" alt="Screen Shot 2021-11-02 at 12 29 39 PM" src="https://user-images.githubusercontent.com/2319279/139908656-7bedc092-df07-44aa-a351-73a348ce1e1e.png">
